### PR TITLE
Fix case where vanished spectating players are playing and therefore being vanished during the game

### DIFF
--- a/src/main/java/dev/pgm/events/commands/TournamentAdminCommands.java
+++ b/src/main/java/dev/pgm/events/commands/TournamentAdminCommands.java
@@ -10,7 +10,10 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.command.CommandSender;
+import tc.oc.pgm.api.PGM;
 import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.match.MatchManager;
+import tc.oc.pgm.api.player.VanishManager;
 import tc.oc.pgm.lib.app.ashcon.intake.Command;
 import tc.oc.pgm.lib.app.ashcon.intake.parametric.annotation.Text;
 
@@ -34,6 +37,14 @@ public class TournamentAdminCommands {
       sender.sendMessage(ChatColor.RED + "Team not found!");
       return;
     }
+
+    VanishManager vanishManager = PGM.get().getVanishManager();
+    MatchManager matchManager = PGM.get().getMatchManager();
+
+    for (TournamentPlayer player : team.getPlayers())
+      if (vanishManager.isVanished(player.getUUID()))
+        vanishManager.setVanished(
+            matchManager.getPlayer(Bukkit.getPlayer(player.getUUID())), false, false);
 
     teamManager.addTeam(team);
     sender.sendMessage(ChatColor.YELLOW + "Added team " + team.getName() + "!");

--- a/src/main/java/dev/pgm/events/listeners/PlayerJoinListen.java
+++ b/src/main/java/dev/pgm/events/listeners/PlayerJoinListen.java
@@ -70,7 +70,8 @@ public class PlayerJoinListen implements Listener {
 
   @EventHandler(priority = EventPriority.HIGH)
   public void vanish(PlayerJoinEvent event) {
-    if (event.getPlayer().hasPermission("events.spectate.vanish"))
+    if (event.getPlayer().hasPermission("events.spectate.vanish")
+        && !manager.playerTeam(event.getPlayer().getUniqueId()).isPresent())
       PGM.get()
           .getVanishManager()
           .setVanished(PGM.get().getMatchManager().getPlayer(event.getPlayer()), true, true);


### PR DESCRIPTION
If a player with the permission `events.spectate.vanish` is on a registered team, they will be forced onto a team but will remain vanished.

This commit will unvanish players when their team is registered and also will not vanish players if they are on a registered team when joining the server.