### PR TITLE
Allow TournamentTeam interface to return extended players list

### DIFF
--- a/src/main/java/dev/pgm/events/team/TournamentTeam.java
+++ b/src/main/java/dev/pgm/events/team/TournamentTeam.java
@@ -12,7 +12,7 @@ public interface TournamentTeam {
 
   String getName();
 
-  List<TournamentPlayer> getPlayers();
+  List<? extends TournamentPlayer> getPlayers();
 
   default boolean containsPlayer(UUID player) {
     return getPlayers().stream().anyMatch(x -> x.getUUID().equals(player));


### PR DESCRIPTION
Allows third-party plugins to create their own implementation of the `TournamentPlayer` interface and still work in a team. 👍 

Other areas of the code look to allow this so this method seems to be an anomaly.

Signed-off-by: Pugzy <pugzy@mail.com>