### PR TITLE
Add extra config options for ready process

### DIFF
--- a/src/main/java/dev/pgm/events/Tournament.java
+++ b/src/main/java/dev/pgm/events/Tournament.java
@@ -9,6 +9,7 @@ import dev.pgm.events.listeners.PlayerJoinListen;
 import dev.pgm.events.ready.ReadyCommands;
 import dev.pgm.events.ready.ReadyListener;
 import dev.pgm.events.ready.ReadyManager;
+import dev.pgm.events.ready.ReadyManagerImpl;
 import dev.pgm.events.ready.ReadyParties;
 import dev.pgm.events.ready.ReadySystem;
 import dev.pgm.events.team.ConfigTeamParser;
@@ -42,11 +43,9 @@ public class Tournament extends JavaPlugin {
     tournamentManager = new TournamentManager();
     ConfigTeamParser.getInstance(); // load teams now
 
-    ReadySystem system = new ReadySystem();
-    ReadyParties parties = new ReadyParties();
-    ReadyManager readyManager = new ReadyManager(system, parties);
-    ReadyListener readyListener = new ReadyListener(readyManager, system, parties);
-    ReadyCommands readyCommands = new ReadyCommands(readyManager, system, parties);
+    ReadyManager readyManager = new ReadyManagerImpl(new ReadySystem(), new ReadyParties());
+    ReadyListener readyListener = new ReadyListener(readyManager);
+    ReadyCommands readyCommands = new ReadyCommands(readyManager);
 
     BasicBukkitCommandGraph g =
         new BasicBukkitCommandGraph(new CommandModule(tournamentManager, teamManager));

--- a/src/main/java/dev/pgm/events/Tournament.java
+++ b/src/main/java/dev/pgm/events/Tournament.java
@@ -8,6 +8,7 @@ import dev.pgm.events.listeners.MatchLoadListener;
 import dev.pgm.events.listeners.PlayerJoinListen;
 import dev.pgm.events.ready.ReadyCommands;
 import dev.pgm.events.ready.ReadyListener;
+import dev.pgm.events.ready.ReadyManager;
 import dev.pgm.events.ready.ReadyParties;
 import dev.pgm.events.ready.ReadySystem;
 import dev.pgm.events.team.ConfigTeamParser;
@@ -43,8 +44,9 @@ public class Tournament extends JavaPlugin {
 
     ReadySystem system = new ReadySystem();
     ReadyParties parties = new ReadyParties();
-    ReadyListener readyListener = new ReadyListener(system, parties);
-    ReadyCommands readyCommands = new ReadyCommands(system, parties);
+    ReadyManager readyManager = new ReadyManager(system, parties);
+    ReadyListener readyListener = new ReadyListener(readyManager, system, parties);
+    ReadyCommands readyCommands = new ReadyCommands(readyManager, system, parties);
 
     BasicBukkitCommandGraph g =
         new BasicBukkitCommandGraph(new CommandModule(tournamentManager, teamManager));

--- a/src/main/java/dev/pgm/events/config/AppData.java
+++ b/src/main/java/dev/pgm/events/config/AppData.java
@@ -5,7 +5,7 @@ import dev.pgm.events.Tournament;
 /**
  * Config options used around the plugin.
  *
- * <p>Values are are stored in the `resources/config.yml`.</p>
+ * <p>Values are are stored in the <code>`resources/config.yml`</code> file.
  */
 public class AppData {
 

--- a/src/main/java/dev/pgm/events/config/AppData.java
+++ b/src/main/java/dev/pgm/events/config/AppData.java
@@ -2,9 +2,26 @@ package dev.pgm.events.config;
 
 import dev.pgm.events.Tournament;
 
+/**
+ * Config options used around the plugin.
+ *
+ * <p>Values are are stored in the `resources/config.yml`.</p>
+ */
 public class AppData {
 
   public static boolean observersMustReady() {
-    return Tournament.get().getConfig().getBoolean("observers-must-ready");
+    return Tournament.get().getConfig().getBoolean("observers-must-ready", true);
+  }
+
+  public static boolean readyFullTeamRequired() {
+    return Tournament.get().getConfig().getBoolean("ready-full-team-required", false);
+  }
+
+  public static boolean readyReminders() {
+    return Tournament.get().getConfig().getBoolean("ready-reminders", true);
+  }
+
+  public static boolean autoUnready() {
+    return Tournament.get().getConfig().getBoolean("auto-unready", false);
   }
 }

--- a/src/main/java/dev/pgm/events/ready/ReadyCommands.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyCommands.java
@@ -1,84 +1,40 @@
 package dev.pgm.events.ready;
 
-import dev.pgm.events.config.AppData;
-import dev.pgm.events.utils.Parties;
-import net.md_5.bungee.api.ChatColor;
+import dev.pgm.events.utils.Response;
 import org.bukkit.command.CommandSender;
-import tc.oc.pgm.api.match.Match;
-import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.lib.app.ashcon.intake.Command;
-import tc.oc.pgm.match.ObserverParty;
+import tc.oc.pgm.util.Audience;
 
 public class ReadyCommands {
 
-  private final ReadyManager readyManager;
+  private final ReadyManager manager;
 
-  public ReadyCommands(
-      ReadyManager readyManager) {
-    this.readyManager = readyManager;
+  public ReadyCommands(ReadyManager readyManager) {
+    this.manager = readyManager;
   }
 
   @Command(aliases = "ready", desc = "Ready up")
-  public void readyCommand(CommandSender sender, Match match, MatchPlayer player) {
-    Party party = player.getParty();
+  public void readyCommand(CommandSender sender, MatchPlayer player) {
+    Response response = manager.canReady(player);
 
-    if (!preConditions(match)) return;
-
-    if (!canReady(sender, player)) return;
-
-    if (readyManager.isReady(party)) {
-      sender.sendMessage(ChatColor.RED + "You are already ready!");
+    if (response.isDenied()) {
+      Audience.get(sender).sendWarning(response.getMessage());
       return;
     }
 
-    if (AppData.readyFullTeamRequired() && !Parties.isFull(party)) {
-      sender.sendMessage(ChatColor.RED + "You can not ready until your team is full!");
-      return;
-    }
-
-    readyManager.readyTeam(party);
+    manager.ready(player.getParty());
   }
 
   @Command(aliases = "unready", desc = "Mark your team as no longer being ready")
-  public void unreadyCommand(CommandSender sender, Match match, MatchPlayer player) {
-    Party party = player.getParty();
+  public void unreadyCommand(CommandSender sender, MatchPlayer player) {
+    Response response = manager.canUnready(player);
 
-    if (!preConditions(match)) return;
-
-    if (!canReady(sender, player)) return;
-
-    if (!readyManager.isReady(party)) {
-      sender.sendMessage(ChatColor.RED + "You are already unready!");
+    if (response.isDenied()) {
+      Audience.get(sender).sendWarning(response.getMessage());
       return;
     }
 
-    if (readyManager.allReady(match)) {
-      readyManager.unreadyTeam(party);
-      if (readyManager.unreadyShouldCancel()) {
-        // check if unready should cancel
-        readyManager.cancelMatchStart(match);
-      }
-    } else {
-      readyManager.readyTeam(party);
-    }
-  }
-
-  private boolean preConditions(Match match) {
-    return !match.isRunning() && !match.isFinished();
-  }
-
-  private boolean canReady(CommandSender sender, MatchPlayer player) {
-    if (!readyManager.canReadyAction()) {
-      sender.sendMessage(ChatColor.RED + "You are not able to ready at this time!");
-      return false;
-    }
-
-    if (!AppData.observersMustReady() && player.getParty() instanceof ObserverParty) {
-      sender.sendMessage(ChatColor.RED + "Observers are not allowed to ready!");
-      return false;
-    }
-
-    return !(player.getParty() instanceof ObserverParty) || sender.hasPermission("events.staff");
+    manager.unready(player.getParty());
   }
 }

--- a/src/main/java/dev/pgm/events/ready/ReadyListener.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyListener.java
@@ -2,10 +2,8 @@ package dev.pgm.events.ready;
 
 import dev.pgm.events.Tournament;
 import dev.pgm.events.config.AppData;
-import java.time.Duration;
-import java.util.Optional;
-
 import dev.pgm.events.utils.Parties;
+import java.util.Optional;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -22,7 +20,6 @@ import tc.oc.pgm.lib.net.kyori.adventure.text.Component;
 import tc.oc.pgm.lib.net.kyori.adventure.text.format.NamedTextColor;
 import tc.oc.pgm.match.ObserverParty;
 import tc.oc.pgm.start.StartCountdown;
-import tc.oc.pgm.start.StartMatchModule;
 import tc.oc.pgm.teams.Team;
 
 public class ReadyListener implements Listener {
@@ -35,20 +32,12 @@ public class ReadyListener implements Listener {
 
   @EventHandler
   public void onQueueStart(CountdownStartEvent event) {
-    if (event.getCountdown() instanceof StartCountdown)
-      manager.onStart(event.getMatch(), ((StartCountdown) event.getCountdown()).getRemaining());
+    if (event.getCountdown() instanceof StartCountdown) manager.handleCountdownStart(event);
   }
 
   @EventHandler
   public void onCancel(CountdownCancelEvent event) {
-    if (!(event.getCountdown() instanceof StartCountdown)) return;
-
-    Duration remaining = manager.cancelDuration(event.getMatch());
-    if (remaining != null)
-      event
-          .getMatch()
-          .needModule(StartMatchModule.class)
-          .forceStartCountdown(remaining, Duration.ZERO);
+    if (event.getCountdown() instanceof StartCountdown) manager.handleCountdownCancel(event);
   }
 
   @EventHandler
@@ -69,7 +58,7 @@ public class ReadyListener implements Listener {
 
     // if match starting and team was ready unready them
     if (event.getMatch().getPhase() == MatchPhase.STARTING && manager.isReady(party)) {
-      manager.unreadyTeam(party);
+      manager.unready(party);
     }
   }
 

--- a/src/main/java/dev/pgm/events/ready/ReadyListener.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyListener.java
@@ -12,7 +12,6 @@ import tc.oc.pgm.api.match.MatchPhase;
 import tc.oc.pgm.api.match.event.MatchLoadEvent;
 import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
-import tc.oc.pgm.events.CountdownCancelEvent;
 import tc.oc.pgm.events.CountdownStartEvent;
 import tc.oc.pgm.events.PlayerLeaveMatchEvent;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
@@ -33,11 +32,6 @@ public class ReadyListener implements Listener {
   @EventHandler
   public void onQueueStart(CountdownStartEvent event) {
     if (event.getCountdown() instanceof StartCountdown) manager.handleCountdownStart(event);
-  }
-
-  @EventHandler
-  public void onCancel(CountdownCancelEvent event) {
-    if (event.getCountdown() instanceof StartCountdown) manager.handleCountdownCancel(event);
   }
 
   @EventHandler

--- a/src/main/java/dev/pgm/events/ready/ReadyListener.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyListener.java
@@ -1,20 +1,36 @@
 package dev.pgm.events.ready;
 
+import dev.pgm.events.Tournament;
+import dev.pgm.events.config.AppData;
 import java.time.Duration;
+import java.util.Optional;
+import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
+import tc.oc.pgm.api.match.MatchPhase;
 import tc.oc.pgm.api.match.event.MatchLoadEvent;
+import tc.oc.pgm.api.party.Party;
+import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.CountdownCancelEvent;
 import tc.oc.pgm.events.CountdownStartEvent;
+import tc.oc.pgm.events.PlayerLeaveMatchEvent;
+import tc.oc.pgm.events.PlayerPartyChangeEvent;
+import tc.oc.pgm.lib.net.kyori.adventure.text.Component;
+import tc.oc.pgm.lib.net.kyori.adventure.text.format.NamedTextColor;
+import tc.oc.pgm.match.ObserverParty;
 import tc.oc.pgm.start.StartCountdown;
 import tc.oc.pgm.start.StartMatchModule;
+import tc.oc.pgm.teams.Team;
 
 public class ReadyListener implements Listener {
 
+  private final ReadyManager manager;
   private final ReadySystem system;
   private final ReadyParties parties;
 
-  public ReadyListener(ReadySystem system, ReadyParties parties) {
+  public ReadyListener(ReadyManager manager, ReadySystem system, ReadyParties parties) {
+    this.manager = manager;
     this.system = system;
     this.parties = parties;
   }
@@ -42,5 +58,52 @@ public class ReadyListener implements Listener {
   @EventHandler
   public void onStart(MatchLoadEvent event) {
     system.reset();
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onLeave(PlayerLeaveMatchEvent event) {
+    if (!AppData.autoUnready()) {
+      return;
+    }
+
+    Party party = event.getParty();
+    if (party instanceof ObserverParty) {
+      return;
+    }
+
+    // if match starting and team was ready unready them
+    if (event.getMatch().getPhase() == MatchPhase.STARTING && parties.isReady(party)) {
+      manager.unreadyTeam(party);
+    }
+  }
+
+  @EventHandler(priority = EventPriority.MONITOR)
+  public void onPartyChange(PlayerPartyChangeEvent event) {
+    if (!AppData.readyReminders()) {
+      return;
+    }
+
+    MatchPlayer player = event.getPlayer();
+    Optional<Team> playerTeam = Tournament.get().getTeamManager().playerTeam(player.getId());
+
+    // Add hint to ready up once all players joined
+    if (playerTeam.isPresent()
+        && !event.getMatch().isRunning()
+        && parties.isFull(player.getParty())) {
+      Bukkit.getScheduler()
+          .scheduleSyncDelayedTask(
+              Tournament.get(),
+              () -> {
+                // Delay message sending to ensure after motd message
+                event
+                    .getPlayer()
+                    .getParty()
+                    .sendMessage(
+                        Component.text("Mark your team as ready using ", NamedTextColor.GREEN)
+                            .append(Component.text("/ready", NamedTextColor.YELLOW))
+                            .append(Component.text(".", NamedTextColor.GREEN)));
+              },
+              20);
+    }
   }
 }

--- a/src/main/java/dev/pgm/events/ready/ReadyManager.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyManager.java
@@ -4,7 +4,6 @@ import dev.pgm.events.utils.Response;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
-import tc.oc.pgm.events.CountdownCancelEvent;
 import tc.oc.pgm.events.CountdownStartEvent;
 
 public interface ReadyManager {
@@ -22,8 +21,6 @@ public interface ReadyManager {
   Response canUnready(MatchPlayer player);
 
   void handleCountdownStart(CountdownStartEvent event);
-
-  void handleCountdownCancel(CountdownCancelEvent event);
 
   void reset();
 }

--- a/src/main/java/dev/pgm/events/ready/ReadyManager.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyManager.java
@@ -1,0 +1,70 @@
+package dev.pgm.events.ready;
+
+import java.time.Duration;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.party.Party;
+import tc.oc.pgm.start.StartCountdown;
+import tc.oc.pgm.start.StartMatchModule;
+
+public class ReadyManager {
+
+  private final ReadyParties readyParties;
+  private final ReadySystem readySystem;
+
+  public ReadyManager(ReadySystem readySystem, ReadyParties readyParties) {
+    this.readySystem = readySystem;
+    this.readyParties = readyParties;
+  }
+
+  public void createMatchStart(Match match) {
+    createMatchStart(match, Duration.ofSeconds(20));
+  }
+
+  public void createMatchStart(Match match, Duration duration) {
+    match.needModule(StartMatchModule.class).forceStartCountdown(duration, Duration.ZERO);
+  }
+
+  public void cancelMatchStart(Match match) {
+    match.getCountdown().cancelAll(StartCountdown.class);
+  }
+
+  public void readyTeam(Party party) {
+    if (party.isNamePlural()) {
+      Bukkit.broadcastMessage(
+          party.getColor() + party.getNameLegacy() + ChatColor.RESET + " are now ready.");
+    } else {
+      Bukkit.broadcastMessage(
+          party.getColor() + party.getNameLegacy() + ChatColor.RESET + " is now ready.");
+    }
+
+    readyParties.ready(party);
+
+    Match match = party.getMatch();
+    if (readyParties.allReady(match)) {
+      createMatchStart(match);
+    }
+  }
+
+  public void unreadyTeam(Party party) {
+    if (party.isNamePlural()) {
+      Bukkit.broadcastMessage(
+          party.getColor() + party.getNameLegacy() + ChatColor.RESET + " are now unready.");
+    } else {
+      Bukkit.broadcastMessage(
+          party.getColor() + party.getNameLegacy() + ChatColor.RESET + " is now unready.");
+    }
+
+    Match match = party.getMatch();
+    if (readyParties.allReady(match)) {
+      readyParties.unReady(party);
+      if (readySystem.unreadyShouldCancel()) {
+        // check if unready should cancel
+        cancelMatchStart(party.getMatch());
+      }
+    } else {
+      readyParties.unReady(party);
+    }
+  }
+}

--- a/src/main/java/dev/pgm/events/ready/ReadyManager.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyManager.java
@@ -1,70 +1,36 @@
 package dev.pgm.events.ready;
 
-import java.time.Duration;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Party;
-import tc.oc.pgm.start.StartCountdown;
-import tc.oc.pgm.start.StartMatchModule;
+import tc.oc.pgm.teams.Team;
 
-public class ReadyManager {
+import java.time.Duration;
 
-  private final ReadyParties readyParties;
-  private final ReadySystem readySystem;
+public interface ReadyManager {
 
-  public ReadyManager(ReadySystem readySystem, ReadyParties readyParties) {
-    this.readySystem = readySystem;
-    this.readyParties = readyParties;
-  }
-
-  public void createMatchStart(Match match) {
-    createMatchStart(match, Duration.ofSeconds(20));
-  }
-
-  public void createMatchStart(Match match, Duration duration) {
-    match.needModule(StartMatchModule.class).forceStartCountdown(duration, Duration.ZERO);
-  }
-
-  public void cancelMatchStart(Match match) {
-    match.getCountdown().cancelAll(StartCountdown.class);
-  }
-
-  public void readyTeam(Party party) {
-    if (party.isNamePlural()) {
-      Bukkit.broadcastMessage(
-          party.getColor() + party.getNameLegacy() + ChatColor.RESET + " are now ready.");
-    } else {
-      Bukkit.broadcastMessage(
-          party.getColor() + party.getNameLegacy() + ChatColor.RESET + " is now ready.");
+    default void createMatchStart(Match match) {
+        createMatchStart(match, Duration.ofSeconds(20));
     }
 
-    readyParties.ready(party);
+    void createMatchStart(Match match, Duration duration);
 
-    Match match = party.getMatch();
-    if (readyParties.allReady(match)) {
-      createMatchStart(match);
-    }
-  }
+    void cancelMatchStart(Match match);
 
-  public void unreadyTeam(Party party) {
-    if (party.isNamePlural()) {
-      Bukkit.broadcastMessage(
-          party.getColor() + party.getNameLegacy() + ChatColor.RESET + " are now unready.");
-    } else {
-      Bukkit.broadcastMessage(
-          party.getColor() + party.getNameLegacy() + ChatColor.RESET + " is now unready.");
-    }
+    void readyTeam(Party party);
 
-    Match match = party.getMatch();
-    if (readyParties.allReady(match)) {
-      readyParties.unReady(party);
-      if (readySystem.unreadyShouldCancel()) {
-        // check if unready should cancel
-        cancelMatchStart(party.getMatch());
-      }
-    } else {
-      readyParties.unReady(party);
-    }
-  }
+    void unreadyTeam(Party party);
+
+    boolean isReady(Party party);
+
+    boolean allReady(Match match);
+
+    boolean unreadyShouldCancel();
+
+    boolean canReadyAction();
+
+    void reset();
+
+    Duration cancelDuration(Match match);
+
+    void onStart(Match match, Duration duration);
 }

--- a/src/main/java/dev/pgm/events/ready/ReadyManager.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyManager.java
@@ -1,36 +1,29 @@
 package dev.pgm.events.ready;
 
+import dev.pgm.events.utils.Response;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Party;
-import tc.oc.pgm.teams.Team;
-
-import java.time.Duration;
+import tc.oc.pgm.api.player.MatchPlayer;
+import tc.oc.pgm.events.CountdownCancelEvent;
+import tc.oc.pgm.events.CountdownStartEvent;
 
 public interface ReadyManager {
 
-    default void createMatchStart(Match match) {
-        createMatchStart(match, Duration.ofSeconds(20));
-    }
+  void ready(Party party);
 
-    void createMatchStart(Match match, Duration duration);
+  void unready(Party party);
 
-    void cancelMatchStart(Match match);
+  boolean isReady(Party party);
 
-    void readyTeam(Party party);
+  boolean allReady(Match match);
 
-    void unreadyTeam(Party party);
+  Response canReady(MatchPlayer player);
 
-    boolean isReady(Party party);
+  Response canUnready(MatchPlayer player);
 
-    boolean allReady(Match match);
+  void handleCountdownStart(CountdownStartEvent event);
 
-    boolean unreadyShouldCancel();
+  void handleCountdownCancel(CountdownCancelEvent event);
 
-    boolean canReadyAction();
-
-    void reset();
-
-    Duration cancelDuration(Match match);
-
-    void onStart(Match match, Duration duration);
+  void reset();
 }

--- a/src/main/java/dev/pgm/events/ready/ReadyManagerImpl.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyManagerImpl.java
@@ -1,0 +1,109 @@
+package dev.pgm.events.ready;
+
+import java.time.Duration;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.api.party.Party;
+import tc.oc.pgm.start.StartCountdown;
+import tc.oc.pgm.start.StartMatchModule;
+import tc.oc.pgm.teams.Team;
+
+public class ReadyManagerImpl implements ReadyManager {
+
+  private final ReadyParties parties;
+  private final ReadySystem system;
+
+  public ReadyManagerImpl(ReadySystem system, ReadyParties parties) {
+    this.system = system;
+    this.parties = parties;
+  }
+
+  @Override
+  public void createMatchStart(Match match, Duration duration) {
+    match.needModule(StartMatchModule.class).forceStartCountdown(duration, Duration.ZERO);
+  }
+
+  @Override
+  public void cancelMatchStart(Match match) {
+    match.getCountdown().cancelAll(StartCountdown.class);
+  }
+
+  @Override
+  public void readyTeam(Party party) {
+    if (party.isNamePlural()) {
+      Bukkit.broadcastMessage(
+          party.getColor() + party.getNameLegacy() + ChatColor.RESET + " are now ready.");
+    } else {
+      Bukkit.broadcastMessage(
+          party.getColor() + party.getNameLegacy() + ChatColor.RESET + " is now ready.");
+    }
+
+    parties.ready(party);
+
+    Match match = party.getMatch();
+    if (parties.allReady(match)) {
+      createMatchStart(match);
+    }
+  }
+
+  @Override
+  public void unreadyTeam(Party party) {
+    if (party.isNamePlural()) {
+      Bukkit.broadcastMessage(
+          party.getColor() + party.getNameLegacy() + ChatColor.RESET + " are now unready.");
+    } else {
+      Bukkit.broadcastMessage(
+          party.getColor() + party.getNameLegacy() + ChatColor.RESET + " is now unready.");
+    }
+
+    Match match = party.getMatch();
+    if (parties.allReady(match)) {
+      parties.unReady(party);
+      if (system.unreadyShouldCancel()) {
+        // check if unready should cancel
+        cancelMatchStart(party.getMatch());
+      }
+    } else {
+      parties.unReady(party);
+    }
+  }
+
+  @Override
+  public boolean isReady(Party party) {
+    return parties.isReady(party);
+  }
+
+  @Override
+  public boolean allReady(Match match) {
+    return parties.allReady(match);
+  }
+
+  @Override
+  public boolean unreadyShouldCancel() {
+    return system.unreadyShouldCancel();
+  }
+
+  @Override
+  public boolean canReadyAction() {
+    return system.canReadyAction();
+  }
+
+  @Override
+  public void reset() {
+    parties.reset();
+    system.reset();
+  }
+
+  @Override
+  public Duration cancelDuration(Match match) {
+    return system.onCancel(this.allReady(match));
+  }
+
+  @Override
+  public void onStart(Match match, Duration duration) {
+    system.onStart(
+            duration,
+            this.allReady(match));
+  }
+}

--- a/src/main/java/dev/pgm/events/ready/ReadyParties.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyParties.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.Set;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Party;
+import tc.oc.pgm.teams.Team;
 
 public class ReadyParties {
 
@@ -28,6 +29,16 @@ public class ReadyParties {
 
   public boolean isReady(Party party) {
     return currentReadyParties.contains(party.getDefaultName());
+  }
+
+  public boolean isFull(Party party) {
+    if (party instanceof Team) {
+      Team team = (Team) party;
+
+      return team.getSize(false) >= team.getMaxPlayers();
+    }
+
+    return false;
   }
 
   public boolean allReady(Match match) {

--- a/src/main/java/dev/pgm/events/ready/ReadyParties.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyParties.java
@@ -18,7 +18,7 @@ public class ReadyParties {
     currentReadyParties.add(party.getDefaultName());
   }
 
-  public void unReady(Party party) {
+  public void unready(Party party) {
     currentReadyParties.remove(party.getDefaultName());
   }
 

--- a/src/main/java/dev/pgm/events/ready/ReadyParties.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyParties.java
@@ -5,18 +5,13 @@ import java.util.HashSet;
 import java.util.Set;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Party;
-import tc.oc.pgm.teams.Team;
 
 public class ReadyParties {
 
   private final Set<String> currentReadyParties = new HashSet<>();
-  private String currentMatchID;
 
-  public void preconditionsCheckMatch(Match match) {
-    if (!match.getId().equals(currentMatchID)) {
-      currentMatchID = match.getId();
-      currentReadyParties.clear();
-    }
+  public void reset() {
+    currentReadyParties.clear();
   }
 
   public void ready(Party party) {
@@ -29,16 +24,6 @@ public class ReadyParties {
 
   public boolean isReady(Party party) {
     return currentReadyParties.contains(party.getDefaultName());
-  }
-
-  public boolean isFull(Party party) {
-    if (party instanceof Team) {
-      Team team = (Team) party;
-
-      return team.getSize(false) >= team.getMaxPlayers();
-    }
-
-    return false;
   }
 
   public boolean allReady(Match match) {

--- a/src/main/java/dev/pgm/events/ready/ReadySystem.java
+++ b/src/main/java/dev/pgm/events/ready/ReadySystem.java
@@ -18,7 +18,7 @@ public class ReadySystem {
     runningSmallerCountdown = false;
   }
 
-  public boolean canReadyAction() {
+  public boolean canReady() {
     if (timestamp == null || countdownLength == null) return true;
 
     return remaining().compareTo(Duration.ofSeconds(21)) > 0;

--- a/src/main/java/dev/pgm/events/ready/ReadySystem.java
+++ b/src/main/java/dev/pgm/events/ready/ReadySystem.java
@@ -7,7 +7,6 @@ import javax.annotation.Nullable;
 
 public class ReadySystem {
 
-  int cancelCounter = 0;
   private Timestamp timestamp;
   private Duration countdownLength;
   private boolean runningSmallerCountdown = false;
@@ -40,7 +39,6 @@ public class ReadySystem {
     this.timestamp = Timestamp.from(Instant.now());
     this.countdownLength = countdownDuration;
     runningSmallerCountdown = false;
-    cancelCounter = 0;
   }
 
   public boolean unreadyShouldCancel() {
@@ -48,29 +46,10 @@ public class ReadySystem {
     return runningSmallerCountdown;
   }
 
-  public @Nullable Duration onCancel(boolean allReady) {
-    if (allReady && cancelCounter == 1) {
-      // all are ready and still cancel means a manual cancel -- lets just stop everything
-      // counter == 1 means real cancel
-      runningSmallerCountdown = false;
-      timestamp = null;
-      countdownLength = null;
-      cancelCounter = 0;
-      return null;
-    }
-
-    if (allReady && cancelCounter == 0) {
-      cancelCounter = 1;
-      return null;
-    }
-
+  public @Nullable Duration getResetDuration() {
     if (runningSmallerCountdown && timestamp != null) {
       Duration remaining = remaining();
-
-      if (remaining.compareTo(Duration.ZERO) < 1) {
-        // if less than 5 seconds remaining cancel this
-        return Duration.ZERO;
-      }
+      runningSmallerCountdown = false;
 
       return remaining;
     }

--- a/src/main/java/dev/pgm/events/utils/Parties.java
+++ b/src/main/java/dev/pgm/events/utils/Parties.java
@@ -5,13 +5,13 @@ import tc.oc.pgm.teams.Team;
 
 public class Parties {
 
-    public static boolean isFull(Party party) {
-        if (party instanceof Team) {
-            Team team = (Team) party;
+  public static boolean isFull(Party party) {
+    if (party instanceof Team) {
+      Team team = (Team) party;
 
-            return team.getSize(false) >= team.getMaxPlayers();
-        }
-
-        return false;
+      return team.getSize(false) >= team.getMaxPlayers();
     }
+
+    return false;
+  }
 }

--- a/src/main/java/dev/pgm/events/utils/Parties.java
+++ b/src/main/java/dev/pgm/events/utils/Parties.java
@@ -1,0 +1,17 @@
+package dev.pgm.events.utils;
+
+import tc.oc.pgm.api.party.Party;
+import tc.oc.pgm.teams.Team;
+
+public class Parties {
+
+    public static boolean isFull(Party party) {
+        if (party instanceof Team) {
+            Team team = (Team) party;
+
+            return team.getSize(false) >= team.getMaxPlayers();
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/dev/pgm/events/utils/Response.java
+++ b/src/main/java/dev/pgm/events/utils/Response.java
@@ -1,0 +1,43 @@
+package dev.pgm.events.utils;
+
+import javax.annotation.Nullable;
+import tc.oc.pgm.lib.net.kyori.adventure.text.Component;
+
+public class Response {
+
+  boolean allowed;
+  Component message = null;
+
+  public Response(boolean allowed, @Nullable Component message) {
+    this.allowed = allowed;
+    this.message = message;
+  }
+
+  public boolean isAllowed() {
+    return this.allowed;
+  }
+
+  public boolean isDenied() {
+    return !this.allowed;
+  }
+
+  public Component getMessage() {
+    return message;
+  }
+
+  public static Response allow() {
+    return Response.allow(null);
+  }
+
+  public static Response allow(@Nullable Component message) {
+    return new Response(true, message);
+  }
+
+  public static Response deny() {
+    return Response.deny(null);
+  }
+
+  public static Response deny(@Nullable Component message) {
+    return new Response(false, message);
+  }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,2 +1,13 @@
 # default config
+
+# the observer team must ready up
 observers-must-ready: true
+
+# only allow ready if team is full
+ready-full-team-required: false
+
+# remind team to ready when team full
+ready-reminders: true
+
+# unready if a team player leaves
+auto-unready: false


### PR DESCRIPTION
Moved some features I added to Bolt's `ingame` that could be useful elsewhere.

Added a `ReadyManager` to adding centralised location to ready and unready teams so it can be used in both listener and commands (looks like the ready system is due a refactor soon) but didn't want to make a big mess currently.

Added three extra config fields.

- `ready-full-team-required` Prevent teams from running `ready` command before team full
- `ready-reminders` Remind a team to `ready` when all its members have joined
- `auto-unready` Auto unready a team if a player from it leaves

Signed-off-by: Pugzy <pugzy@mail.com>