### PR TITLE
Move veto and ready commands to base command node

### DIFF
--- a/src/main/java/dev/pgm/events/Tournament.java
+++ b/src/main/java/dev/pgm/events/Tournament.java
@@ -2,6 +2,7 @@ package dev.pgm.events;
 
 import dev.pgm.events.commands.TournamentAdminCommands;
 import dev.pgm.events.commands.TournamentUserCommands;
+import dev.pgm.events.commands.VetoCommands;
 import dev.pgm.events.commands.providers.TournamentProvider;
 import dev.pgm.events.format.TournamentFormat;
 import dev.pgm.events.listeners.MatchLoadListener;
@@ -47,18 +48,21 @@ public class Tournament extends JavaPlugin {
     ReadyListener readyListener = new ReadyListener(readyManager);
     ReadyCommands readyCommands = new ReadyCommands(readyManager);
 
-    BasicBukkitCommandGraph g =
+    BasicBukkitCommandGraph graph =
         new BasicBukkitCommandGraph(new CommandModule(tournamentManager, teamManager));
-    DispatcherNode node = g.getRootDispatcherNode();
-    node = node.registerNode("tourney", "tournament", "tm", "events");
-    node.registerCommands(new TournamentUserCommands());
+
+    DispatcherNode node = graph.getRootDispatcherNode();
+    node.registerCommands(new VetoCommands());
     node.registerCommands(readyCommands);
-    node.registerCommands(new TournamentAdminCommands());
+
+    DispatcherNode subNode = node.registerNode("tourney", "tournament", "tm", "events");
+    subNode.registerCommands(new TournamentUserCommands());
+    subNode.registerCommands(new TournamentAdminCommands());
 
     Bukkit.getPluginManager().registerEvents(new MatchLoadListener(teamManager), this);
     Bukkit.getPluginManager().registerEvents(new PlayerJoinListen(teamManager), this);
     Bukkit.getPluginManager().registerEvents(readyListener, this);
-    new CommandExecutor(this, g).register();
+    new CommandExecutor(this, graph).register();
   }
 
   @Override

--- a/src/main/java/dev/pgm/events/commands/TournamentUserCommands.java
+++ b/src/main/java/dev/pgm/events/commands/TournamentUserCommands.java
@@ -4,17 +4,11 @@ import dev.pgm.events.Tournament;
 import dev.pgm.events.format.TournamentFormat;
 import dev.pgm.events.format.rounds.RoundDescription;
 import dev.pgm.events.format.rounds.format.FormatTournamentImpl;
-import dev.pgm.events.format.rounds.veto.VetoRound;
-import dev.pgm.events.team.TournamentTeam;
-import dev.pgm.events.team.TournamentTeamManager;
 import java.util.Optional;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.ChatColor;
 import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.lib.app.ashcon.intake.Command;
-import tc.oc.pgm.lib.app.ashcon.intake.parametric.annotation.Text;
 
 public class TournamentUserCommands {
 
@@ -33,54 +27,6 @@ public class TournamentUserCommands {
       }
     } else {
       sender.sendMessage(format.currentScore().condensed());
-    }
-  }
-
-  @Command(aliases = "veto", desc = "Veto a map")
-  public void veto(
-      CommandSender sender,
-      Match match,
-      TournamentTeamManager teamManager,
-      TournamentFormat format,
-      @Text String option) {
-    if (format.currentRound() == null || !(format.currentRound() instanceof VetoRound)) {
-      sender.sendMessage(ChatColor.RED + "Veto round is not currently running!");
-      return;
-    }
-
-    if (!(sender instanceof Player)) {
-      sender.sendMessage(ChatColor.RED + "Only players can run this command!");
-      return;
-    }
-
-    Player player = (Player) sender;
-    Optional<TournamentTeam> team = teamManager.tournamentTeamPlayer((player).getUniqueId());
-    if (!team.isPresent()) {
-      sender.sendMessage(ChatColor.RED + "Only players on teams can run this command!");
-      return;
-    }
-
-    if (!team.get().canVeto(player)) {
-      sender.sendMessage(ChatColor.RED + "You are not registered as a vetoer for this team!");
-      return;
-    }
-
-    try {
-      int num = Integer.parseInt(option) - 1;
-      VetoRound vetoRound = (VetoRound) format.currentRound();
-      if (!vetoRound.validVetoNumber(num)) {
-        sender.sendMessage(ChatColor.RED + "That is not a valid veto number: " + (num + 1));
-        return;
-      }
-
-      if (!vetoRound.picking().equals(team)) {
-        sender.sendMessage(ChatColor.RED + "It isn't your turn to veto!");
-        return;
-      }
-
-      vetoRound.veto(match, team.get(), num);
-    } catch (NumberFormatException e) {
-      sender.sendMessage(ChatColor.RED + "Invalid argument! Only takes numbers!");
     }
   }
 

--- a/src/main/java/dev/pgm/events/commands/VetoCommands.java
+++ b/src/main/java/dev/pgm/events/commands/VetoCommands.java
@@ -1,0 +1,64 @@
+package dev.pgm.events.commands;
+
+import dev.pgm.events.format.TournamentFormat;
+import dev.pgm.events.format.rounds.veto.VetoRound;
+import dev.pgm.events.team.TournamentTeam;
+import dev.pgm.events.team.TournamentTeamManager;
+import java.util.Optional;
+import org.bukkit.ChatColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import tc.oc.pgm.api.match.Match;
+import tc.oc.pgm.lib.app.ashcon.intake.Command;
+import tc.oc.pgm.lib.app.ashcon.intake.parametric.annotation.Text;
+
+public class VetoCommands {
+
+  @Command(aliases = "veto", desc = "Veto a map")
+  public void veto(
+      CommandSender sender,
+      Match match,
+      TournamentTeamManager teamManager,
+      TournamentFormat format,
+      @Text String option) {
+    if (format.currentRound() == null || !(format.currentRound() instanceof VetoRound)) {
+      sender.sendMessage(ChatColor.RED + "Veto round is not currently running!");
+      return;
+    }
+
+    if (!(sender instanceof Player)) {
+      sender.sendMessage(ChatColor.RED + "Only players can run this command!");
+      return;
+    }
+
+    Player player = (Player) sender;
+    Optional<TournamentTeam> team = teamManager.tournamentTeamPlayer((player).getUniqueId());
+    if (!team.isPresent()) {
+      sender.sendMessage(ChatColor.RED + "Only players on teams can run this command!");
+      return;
+    }
+
+    if (!team.get().canVeto(player)) {
+      sender.sendMessage(ChatColor.RED + "You are not registered as a vetoer for this team!");
+      return;
+    }
+
+    try {
+      int num = Integer.parseInt(option) - 1;
+      VetoRound vetoRound = (VetoRound) format.currentRound();
+      if (!vetoRound.validVetoNumber(num)) {
+        sender.sendMessage(ChatColor.RED + "That is not a valid veto number: " + (num + 1));
+        return;
+      }
+
+      if (!vetoRound.picking().equals(team)) {
+        sender.sendMessage(ChatColor.RED + "It isn't your turn to veto!");
+        return;
+      }
+
+      vetoRound.veto(match, team.get(), num);
+    } catch (NumberFormatException e) {
+      sender.sendMessage(ChatColor.RED + "Invalid argument! Only takes numbers!");
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/PGMDev/Events/issues/12 and makes `ready` easier too.

Don't see either of these commands having conflicts or a real logical reason to be hidden behind `tm` as a subcommand.

Signed-off-by: Pugzy <pugzy@mail.com>