### PR TITLE
Remove unformatted broadcast of winning team name

### DIFF
--- a/src/main/java/dev/pgm/events/format/TournamentFormatImpl.java
+++ b/src/main/java/dev/pgm/events/format/TournamentFormatImpl.java
@@ -165,8 +165,6 @@ public class TournamentFormatImpl implements TournamentFormat {
   }
 
   public void onEnd(Match match, Optional<TournamentTeam> winner) {
-    winner.ifPresent(x -> Bukkit.broadcastMessage(x.getName()));
-
     if (tournamentRoundOptions.shouldAnnounceWinner()) {
       if (winner.isPresent()) {
         Bukkit.broadcastMessage(


### PR DESCRIPTION
Currently, the winner of the match gets broadcast unformatted after the game ends.

![image](https://user-images.githubusercontent.com/8608892/104512660-7513c100-55e6-11eb-871f-1e55337b8e62.png)

I assume this is some left over debugging code as the name is pretty printed a few lines below.
