### PR TITLE
Make ready clickable and phase dependant

### DIFF
--- a/src/main/java/dev/pgm/events/ready/ReadyListener.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyListener.java
@@ -5,7 +5,6 @@ import static tc.oc.pgm.lib.net.kyori.adventure.text.Component.text;
 
 import dev.pgm.events.Tournament;
 import dev.pgm.events.config.AppData;
-import dev.pgm.events.utils.Parties;
 import java.util.Optional;
 import org.bukkit.Bukkit;
 import org.bukkit.event.EventHandler;
@@ -18,6 +17,7 @@ import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.CountdownStartEvent;
 import tc.oc.pgm.events.PlayerLeaveMatchEvent;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
+import tc.oc.pgm.lib.net.kyori.adventure.text.TextComponent;
 import tc.oc.pgm.lib.net.kyori.adventure.text.format.NamedTextColor;
 import tc.oc.pgm.lib.net.kyori.adventure.text.format.Style;
 import tc.oc.pgm.lib.net.kyori.adventure.text.format.TextDecoration;
@@ -60,10 +60,9 @@ public class ReadyListener implements Listener {
     }
   }
 
-  @EventHandler(priority = EventPriority.MONITOR)
+  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
   public void onPartyChange(PlayerPartyChangeEvent event) {
-    if (!AppData.readyReminders()
-        || !event.getMatch().getPhase().canTransitionTo(MatchPhase.RUNNING)) {
+    if (!AppData.readyReminders()) {
       return;
     }
 
@@ -71,21 +70,21 @@ public class ReadyListener implements Listener {
     Optional<Team> playerTeam = Tournament.get().getTeamManager().playerTeam(player.getId());
 
     // Add hint to ready up once all players joined
-    if (playerTeam.isPresent() && Parties.isFull(player.getParty())) {
+    if (playerTeam.isPresent()
+        && manager.canReady(event.getMatch()).isAllowed()
+        && manager.canReady(player.getParty()).isAllowed()) {
+
+      TextComponent readyHint =
+          text("Mark your team as ready using ", NamedTextColor.GREEN)
+              .append(
+                  command(Style.style(NamedTextColor.YELLOW, TextDecoration.UNDERLINED), "ready"));
+
       Bukkit.getScheduler()
           .scheduleSyncDelayedTask(
               Tournament.get(),
               () -> {
                 // Delay message sending to ensure after motd message
-                event
-                    .getPlayer()
-                    .getParty()
-                    .sendMessage(
-                        text("Mark your team as ready using ", NamedTextColor.GREEN)
-                            .append(
-                                command(
-                                    Style.style(NamedTextColor.YELLOW, TextDecoration.UNDERLINED),
-                                    "ready")));
+                player.getParty().sendMessage(readyHint);
               },
               20);
     }

--- a/src/main/java/dev/pgm/events/ready/ReadyListener.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyListener.java
@@ -72,7 +72,7 @@ public class ReadyListener implements Listener {
     // Add hint to ready up once all players joined
     if (playerTeam.isPresent()
         && manager.canReady(event.getMatch()).isAllowed()
-        && manager.canReady(player.getParty()).isAllowed()) {
+        && manager.canReady(playerTeam.get()).isAllowed()) {
 
       TextComponent readyHint =
           text("Mark your team as ready using ", NamedTextColor.GREEN)
@@ -84,7 +84,7 @@ public class ReadyListener implements Listener {
               Tournament.get(),
               () -> {
                 // Delay message sending to ensure after motd message
-                player.getParty().sendMessage(readyHint);
+                playerTeam.get().sendMessage(readyHint);
               },
               20);
     }

--- a/src/main/java/dev/pgm/events/ready/ReadyListener.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyListener.java
@@ -1,5 +1,8 @@
 package dev.pgm.events.ready;
 
+import static dev.pgm.events.utils.Components.command;
+import static tc.oc.pgm.lib.net.kyori.adventure.text.Component.text;
+
 import dev.pgm.events.Tournament;
 import dev.pgm.events.config.AppData;
 import dev.pgm.events.utils.Parties;
@@ -15,8 +18,9 @@ import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.CountdownStartEvent;
 import tc.oc.pgm.events.PlayerLeaveMatchEvent;
 import tc.oc.pgm.events.PlayerPartyChangeEvent;
-import tc.oc.pgm.lib.net.kyori.adventure.text.Component;
 import tc.oc.pgm.lib.net.kyori.adventure.text.format.NamedTextColor;
+import tc.oc.pgm.lib.net.kyori.adventure.text.format.Style;
+import tc.oc.pgm.lib.net.kyori.adventure.text.format.TextDecoration;
 import tc.oc.pgm.match.ObserverParty;
 import tc.oc.pgm.start.StartCountdown;
 import tc.oc.pgm.teams.Team;
@@ -58,7 +62,8 @@ public class ReadyListener implements Listener {
 
   @EventHandler(priority = EventPriority.MONITOR)
   public void onPartyChange(PlayerPartyChangeEvent event) {
-    if (!AppData.readyReminders()) {
+    if (!AppData.readyReminders()
+        || !event.getMatch().getPhase().canTransitionTo(MatchPhase.RUNNING)) {
       return;
     }
 
@@ -66,9 +71,7 @@ public class ReadyListener implements Listener {
     Optional<Team> playerTeam = Tournament.get().getTeamManager().playerTeam(player.getId());
 
     // Add hint to ready up once all players joined
-    if (playerTeam.isPresent()
-        && !event.getMatch().isRunning()
-        && Parties.isFull(player.getParty())) {
+    if (playerTeam.isPresent() && Parties.isFull(player.getParty())) {
       Bukkit.getScheduler()
           .scheduleSyncDelayedTask(
               Tournament.get(),
@@ -78,9 +81,11 @@ public class ReadyListener implements Listener {
                     .getPlayer()
                     .getParty()
                     .sendMessage(
-                        Component.text("Mark your team as ready using ", NamedTextColor.GREEN)
-                            .append(Component.text("/ready", NamedTextColor.YELLOW))
-                            .append(Component.text(".", NamedTextColor.GREEN)));
+                        text("Mark your team as ready using ", NamedTextColor.GREEN)
+                            .append(
+                                command(
+                                    Style.style(NamedTextColor.YELLOW, TextDecoration.UNDERLINED),
+                                    "ready")));
               },
               20);
     }

--- a/src/main/java/dev/pgm/events/ready/ReadyManager.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyManager.java
@@ -16,6 +16,12 @@ public interface ReadyManager {
 
   boolean allReady(Match match);
 
+  Response canReady(Match match);
+
+  Response canReady(Party party);
+
+  Response canUnready(Party party);
+
   Response canReady(MatchPlayer player);
 
   Response canUnready(MatchPlayer player);

--- a/src/main/java/dev/pgm/events/utils/Components.java
+++ b/src/main/java/dev/pgm/events/utils/Components.java
@@ -10,10 +10,10 @@ public class Components {
   /**
    * Creates a formatted and clickable command component.
    *
-   * @param style   formatting of command
+   * @param style formatting of command
    * @param command command with or without `/`
    * @param cmdArgs command arguments
-   * @return        text component
+   * @return text component
    */
   public static Component command(Style style, String command, String... cmdArgs) {
     StringBuilder builder = new StringBuilder();

--- a/src/main/java/dev/pgm/events/utils/Components.java
+++ b/src/main/java/dev/pgm/events/utils/Components.java
@@ -1,0 +1,29 @@
+package dev.pgm.events.utils;
+
+import tc.oc.pgm.lib.net.kyori.adventure.text.Component;
+import tc.oc.pgm.lib.net.kyori.adventure.text.event.ClickEvent;
+import tc.oc.pgm.lib.net.kyori.adventure.text.format.NamedTextColor;
+import tc.oc.pgm.lib.net.kyori.adventure.text.format.Style;
+
+public class Components {
+
+  public static Component command(Style style, String command, String... args) {
+    StringBuilder builder = new StringBuilder();
+    if (!command.startsWith("/")) builder.append("/");
+    builder.append(command);
+
+    for (String arg : args) builder.append(" ").append(Components.toArgument(arg));
+    command = builder.toString();
+
+    return Component.text(command, style)
+        .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, command))
+        .hoverEvent(
+            Component.text("Click to run ", NamedTextColor.GREEN)
+                .append(Component.text(command, style)));
+  }
+
+  static String toArgument(String input) {
+    if (input == null) return null;
+    return input.replace(" ", "┈");
+  }
+}

--- a/src/main/java/dev/pgm/events/utils/Components.java
+++ b/src/main/java/dev/pgm/events/utils/Components.java
@@ -7,12 +7,20 @@ import tc.oc.pgm.lib.net.kyori.adventure.text.format.Style;
 
 public class Components {
 
-  public static Component command(Style style, String command, String... args) {
+  /**
+   * Creates a formatted and clickable command component.
+   *
+   * @param style   formatting of command
+   * @param command command with or without `/`
+   * @param cmdArgs command arguments
+   * @return        text component
+   */
+  public static Component command(Style style, String command, String... cmdArgs) {
     StringBuilder builder = new StringBuilder();
     if (!command.startsWith("/")) builder.append("/");
     builder.append(command);
 
-    for (String arg : args) builder.append(" ").append(Components.toArgument(arg));
+    for (String arg : cmdArgs) builder.append(" ").append(Components.toArgument(arg));
     command = builder.toString();
 
     return Component.text(command, style)
@@ -22,7 +30,7 @@ public class Components {
                 .append(Component.text(command, style)));
   }
 
-  static String toArgument(String input) {
+  private static String toArgument(String input) {
     if (input == null) return null;
     return input.replace(" ", "┈");
   }


### PR DESCRIPTION
Makes the ready-up on full team prompt clickable.

![image](https://user-images.githubusercontent.com/8608892/105638837-e36d4480-5e6c-11eb-889f-8c3330bcedc2.png)

Only shows before the match has started (had issue where it could when not running (so after)).
