### PR TITLE
Fix event priorities for PartyChange and PlayerJoin events

### DIFF
--- a/src/main/java/dev/pgm/events/listeners/PlayerJoinListen.java
+++ b/src/main/java/dev/pgm/events/listeners/PlayerJoinListen.java
@@ -26,7 +26,7 @@ public class PlayerJoinListen implements Listener {
     this.manager = manager;
   }
 
-  @EventHandler(priority = EventPriority.MONITOR)
+  @EventHandler
   public void onJoin(MatchPlayerAddEvent event) {
     Optional<Team> playerTeam = manager.playerTeam(event.getPlayer().getId());
     if (playerTeam.isPresent()) {

--- a/src/main/java/dev/pgm/events/ready/ReadyListener.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyListener.java
@@ -60,7 +60,7 @@ public class ReadyListener implements Listener {
     }
   }
 
-  @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+  @EventHandler(priority = EventPriority.MONITOR)
   public void onPartyChange(PlayerPartyChangeEvent event) {
     if (!AppData.readyReminders()) {
       return;


### PR DESCRIPTION
Currently, `Events` changes the `initialParty` attributes of the `MatchPlayerAddEvent` by setting the initial team. This event listener is registered at priority level monitor which should not happen. PGM now attempts to do logic at monitor level which conflicts with this ordering.

The second change is to the `ReadyListener` removing the `ignoreCancelled = true` on the ``PlayerPartyChangeEvent`` event because I'm unsure why I included it and doesn't make any sense to prompt them to ready up if the event is cancelled. @Pablete1234 any idea?

Signed-off-by: Pugzy <pugzy@mail.com>