### PR TITLE
Announce who updated a teams ready state

### DIFF
--- a/src/main/java/dev/pgm/events/ready/ReadyCommands.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyCommands.java
@@ -23,7 +23,7 @@ public class ReadyCommands {
       return;
     }
 
-    manager.ready(player.getParty());
+    manager.ready(player.getParty(), player);
   }
 
   @Command(aliases = "unready", desc = "Mark your team as no longer being ready")
@@ -35,6 +35,6 @@ public class ReadyCommands {
       return;
     }
 
-    manager.unready(player.getParty());
+    manager.unready(player.getParty(), player);
   }
 }

--- a/src/main/java/dev/pgm/events/ready/ReadyListener.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyListener.java
@@ -56,7 +56,7 @@ public class ReadyListener implements Listener {
 
     // if match starting and team was ready unready them
     if (event.getMatch().getPhase() == MatchPhase.STARTING && manager.isReady(party)) {
-      manager.unready(party);
+      manager.unready(party, null);
     }
   }
 

--- a/src/main/java/dev/pgm/events/ready/ReadyManager.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyManager.java
@@ -1,6 +1,7 @@
 package dev.pgm.events.ready;
 
 import dev.pgm.events.utils.Response;
+import javax.annotation.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
@@ -8,9 +9,9 @@ import tc.oc.pgm.events.CountdownStartEvent;
 
 public interface ReadyManager {
 
-  void ready(Party party);
+  void ready(Party party, @Nullable MatchPlayer player);
 
-  void unready(Party party);
+  void unready(Party party, @Nullable MatchPlayer player);
 
   boolean isReady(Party party);
 

--- a/src/main/java/dev/pgm/events/ready/ReadyManagerImpl.java
+++ b/src/main/java/dev/pgm/events/ready/ReadyManagerImpl.java
@@ -6,16 +6,18 @@ import dev.pgm.events.config.AppData;
 import dev.pgm.events.utils.Parties;
 import dev.pgm.events.utils.Response;
 import java.time.Duration;
-import org.bukkit.Bukkit;
-import org.bukkit.ChatColor;
+import javax.annotation.Nullable;
 import tc.oc.pgm.api.match.Match;
 import tc.oc.pgm.api.match.MatchPhase;
 import tc.oc.pgm.api.party.Party;
 import tc.oc.pgm.api.player.MatchPlayer;
 import tc.oc.pgm.events.CountdownStartEvent;
+import tc.oc.pgm.lib.net.kyori.adventure.text.TextComponent;
+import tc.oc.pgm.lib.net.kyori.adventure.text.format.NamedTextColor;
 import tc.oc.pgm.match.ObserverParty;
 import tc.oc.pgm.start.StartCountdown;
 import tc.oc.pgm.start.StartMatchModule;
+import tc.oc.pgm.util.named.NameStyle;
 
 public class ReadyManagerImpl implements ReadyManager {
 
@@ -36,16 +38,16 @@ public class ReadyManagerImpl implements ReadyManager {
   }
 
   @Override
-  public void ready(Party party) {
+  public void ready(Party party, @Nullable MatchPlayer player) {
     Match match = party.getMatch();
 
-    if (party.isNamePlural()) {
-      Bukkit.broadcastMessage(
-          party.getColor() + party.getNameLegacy() + ChatColor.RESET + " are now ready.");
-    } else {
-      Bukkit.broadcastMessage(
-          party.getColor() + party.getNameLegacy() + ChatColor.RESET + " is now ready.");
-    }
+    TextComponent.Builder message =
+        text()
+            .append(party.getName())
+            .append(text(" marked as ").append(text("ready", NamedTextColor.GREEN)));
+    if (player != null) message.append(text(" by ").append(player.getName(NameStyle.COLOR)));
+
+    match.sendMessage(message);
 
     parties.ready(party);
     if (allReady(match)) {
@@ -54,16 +56,16 @@ public class ReadyManagerImpl implements ReadyManager {
   }
 
   @Override
-  public void unready(Party party) {
+  public void unready(Party party, @Nullable MatchPlayer player) {
     Match match = party.getMatch();
 
-    if (party.isNamePlural()) {
-      Bukkit.broadcastMessage(
-          party.getColor() + party.getNameLegacy() + ChatColor.RESET + " are now unready.");
-    } else {
-      Bukkit.broadcastMessage(
-          party.getColor() + party.getNameLegacy() + ChatColor.RESET + " is now unready.");
-    }
+    TextComponent.Builder message =
+        text()
+            .append(party.getName())
+            .append(text(" marked as ").append(text("unready", NamedTextColor.RED)));
+    if (player != null) message.append(text(" by ").append(player.getName(NameStyle.COLOR)));
+
+    match.sendMessage(message);
 
     if (allReady(match) && system.unreadyShouldCancel()) {
       // check if unready should cancel


### PR DESCRIPTION
- Broadcast who ran the `/ready` and `/unready` commands.
- Reword to no longer require plural version.
- Color ready/unread state to make the message clearer.

![image](https://user-images.githubusercontent.com/8608892/162488763-93d78e67-891d-4755-9b14-9095e8aa0d18.png)


Signed-off-by: Pugzy <pugzy@mail.com>