### PR TITLE
Fix being unable to register teams with offline players

### DIFF
--- a/src/main/java/dev/pgm/events/commands/TournamentAdminCommands.java
+++ b/src/main/java/dev/pgm/events/commands/TournamentAdminCommands.java
@@ -54,7 +54,7 @@ public class TournamentAdminCommands {
     for (TournamentPlayer player : team.getPlayers()) {
       Player bukkit = Bukkit.getPlayer(player.getUUID());
       MatchPlayer mp = matchManager.getPlayer(bukkit);
-      if (Integration.isVanished(bukkit)) Integration.setVanished(mp, false, false);
+      if (bukkit != null && Integration.isVanished(bukkit)) Integration.setVanished(mp, false, false);
     }
 
     teamManager.addTeam(team);


### PR DESCRIPTION
Currently, trying to register teams which have offline members would throw an error due to trying to check if said members are vanished. This fix will simply not call the method if the player is offline.