### PR TITLE
Avoid actioning participation stop events for leavers

### DIFF
--- a/src/main/java/dev/pgm/events/listeners/PlayerJoinListen.java
+++ b/src/main/java/dev/pgm/events/listeners/PlayerJoinListen.java
@@ -100,6 +100,9 @@ public class PlayerJoinListen implements Listener {
 
   @EventHandler
   public void onLeaveParticipate(PlayerParticipationStopEvent event) {
+    // do not do anything when a player is leaving the server
+    if (event.getNextParty() == null) return;
+
     Optional<Team> playerTeam = manager.playerTeam(event.getPlayer().getId());
     // check if the player is on one of the teams
 


### PR DESCRIPTION
If a player is leaving the server (from a team to no team) then the plugin currently tries to cancel that.

This isn't really possible, the option only exists as a team switch calls the same method (with actual teams).
The event getting "cancelled" can break things upstream in PGM where it no longer reacts to the event.

One example of this is the activity tracker which stores data about when a player left, this is listened for in PGM following the `PlayerParticipationStopEvent`, if this is cancelled then no data is stored for a leaving player.